### PR TITLE
Add Fahrenheit support

### DIFF
--- a/src/main/java/com/lumintorious/tfcambiental/TFCAmbientalConfig.java
+++ b/src/main/java/com/lumintorious/tfcambiental/TFCAmbientalConfig.java
@@ -82,6 +82,8 @@ public class TFCAmbientalConfig
 
     public static class ClientImpl
     {
+        public final ForgeConfigSpec.BooleanValue useFahrenheit;
+        
         public final ForgeConfigSpec.DoubleValue noiseDarkness;
         public final ForgeConfigSpec.IntValue noiseLevels;
         public final ForgeConfigSpec.IntValue noiseArea;
@@ -94,6 +96,10 @@ public class TFCAmbientalConfig
 
         ClientImpl(ForgeConfigSpec.Builder builder) {
             builder.comment("For all ARGB values, set to 00000000 to disable the feature in that season");
+
+            isFahrenheit = builder
+                    .comment("Change temperature display to Fahrenheit.")
+                    .define("useFahrenheit", false);
 
             noiseDarkness = builder
                     .comment("How dark should the noise be at most? Set to 0 to disable noise entirely")

--- a/src/main/java/com/lumintorious/tfcambiental/TFCAmbientalGuiRenderer.java
+++ b/src/main/java/com/lumintorious/tfcambiental/TFCAmbientalGuiRenderer.java
@@ -15,6 +15,8 @@ import net.minecraftforge.client.gui.overlay.ForgeGui;
 import net.minecraftforge.common.ForgeMod;
 import org.lwjgl.opengl.GL11;
 
+import static com.lumintorious.tfcambiental.TFCAmbientalConfig.CLIENT;
+
 @OnlyIn(Dist.CLIENT)
 public class TFCAmbientalGuiRenderer
 {
@@ -89,7 +91,7 @@ public class TFCAmbientalGuiRenderer
                 }
 
                 Font f = gui.getFont();
-                String tempStr = String.format("%.1f\u00BA -> %.1f\u00BA", tempSystem.getTemperature(), tempSystem.getTargetTemperature());
+                String tempStr = String.format("%.1f\u00BA -> %.1f\u00BA", scaleTemperature(tempSystem.getTemperature()), scaleTemperature(tempSystem.getTargetTemperature()));
                 stack.drawString(f, tempStr, mid + 50 - f.width(tempStr) / 2F, armorRowHeight + 1 - shiftHeight, TFCAmbientalGuiRenderer.getIntFromColor(redCol, greenCol, blueCol), false);
 
                 String wetStr = String.format("%.1f -> %.1f", tempSystem.getWetness(), Math.max(0, tempSystem.getTargetWetness()));
@@ -175,5 +177,13 @@ public class TFCAmbientalGuiRenderer
         B = B & 0x000000FF;
 
         return 0xFF000000 | R | G | B;
+    }
+
+    private static int scaleTemperature(int celsius) {
+        if (CLIENT.useFahrenheit.get()) {
+            return celsius * (9d/5) + 32;
+        } else {
+            return celsius;
+        }
     }
 }


### PR DESCRIPTION
Yes, I am aware that Imperial is objectively a worse measurement system than Metric.  The problem is that as a dumb stupid American, I have no idea how 20 degrees Celsius relates to the temperatures I experience every day.  To me, 70 degrees Fahrenheit is a nice cozy day, so I don't realize I need to seek shelter at only 40 degrees Celsius.

This commit adds a config option to scale displayed temperatures to degrees Fahrenheit instead of Celsius.  All temperatures remain calculated in Celsius on the backend, this config option just converts them when they're shown in the UI.